### PR TITLE
Quality of life improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,12 @@
-
 /**/__pycache__/
 /**/.idea/
+/.vscode
+
 tvlgen.zip
 
 *.log
+tvlgen.log
+tvlgen.log.*
 
-tvlgen.log.1
+/build
 
-tvlgen.log.2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,32 @@
+cmake_minimum_required(VERSION 3.13)
+project(tvl)
+
+# gather lscpu flags
+set(TVL_LSCPU_FLAGS "" CACHE STRING "lscpu flags for --targets, will attempt to call lscpu if empty")
+if(TVL_LSCPU_FLAGS STREQUAL "")
+    execute_process(
+        COMMAND "sh" "-c" "lscpu | sed -n 's/Flags:\\s*\\(.*\\)/\\1/p' | tr ' ' ';'"
+        OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE TVL_LSCPU_FLAGS
+    )
+endif()
+if(TVL_LSCPU_FLAGS STREQUAL "")
+    message(FATAL_ERROR "failed to deduce TVL_LSCPU_FLAGS, please specify manually")
+endif()
+
+# run generator, this could be made 'lazy' using the strategy from tslgen.cmake
+set(GENERATOR_OUTPUT_PATH "${CMAKE_CURRENT_BINARY_DIR}/generator_output")
+message(STATUS "lscpu flags: ${TVL_LSCPU_FLAGS}")
+message(STATUS "running generator...")
+execute_process(
+    COMMAND python3 "${CMAKE_CURRENT_SOURCE_DIR}/main.py" --no-workaround-warnings --no-concepts -o "${GENERATOR_OUTPUT_PATH}" --targets ${TVL_LSCPU_FLAGS}
+    COMMAND_ERROR_IS_FATAL ANY
+)
+
+add_subdirectory("${GENERATOR_OUTPUT_PATH}")
+
+# disable -W-attributes
+include(CheckCXXCompilerFlag)
+check_cxx_compiler_flag(-Wno-attributes HAVE_W_NO_ATTRIBUTES)
+if (HAVE_W_NO_ATTRIBUTES)
+    target_compile_options(tvl INTERFACE -Wno-attributes)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,13 @@
 cmake_minimum_required(VERSION 3.13)
 project(tvl)
 
+find_package(Python3 REQUIRED)
+
 # gather lscpu flags
 set(TVL_LSCPU_FLAGS "" CACHE STRING "space separated lscpu flags for --targets, will attempt to call lscpu if empty")
 if(TVL_LSCPU_FLAGS STREQUAL "")
     execute_process(
-        COMMAND "sh" "-c" "lscpu | sed -n 's/Flags:\\s*\\(.*\\)/\\1/p'"
+        COMMAND "${Python3_EXECUTABLE}" -c "import cpuinfo; print(*cpuinfo.get_cpu_info()['flags'])"
         OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE TVL_LSCPU_FLAGS
     )
 endif()
@@ -30,8 +32,6 @@ set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${TVL_GENERATOR_S
 
 # run the generator
 set(GENERATOR_OUTPUT_PATH "${CMAKE_CURRENT_BINARY_DIR}/generator_output")
-find_package(Python3 REQUIRED)
-
 message(STATUS "Running TVL Generator...")
 execute_process(
     COMMAND "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/main.py" --no-workaround-warnings --no-concepts -o "${GENERATOR_OUTPUT_PATH}" --targets ${LSCPU_FLAGS_LIST}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,23 +2,24 @@ cmake_minimum_required(VERSION 3.13)
 project(tvl)
 
 # gather lscpu flags
-set(TVL_LSCPU_FLAGS "" CACHE STRING "lscpu flags for --targets, will attempt to call lscpu if empty")
+set(TVL_LSCPU_FLAGS "" CACHE STRING "space separated lscpu flags for --targets, will attempt to call lscpu if empty")
 if(TVL_LSCPU_FLAGS STREQUAL "")
     execute_process(
-        COMMAND "sh" "-c" "lscpu | sed -n 's/Flags:\\s*\\(.*\\)/\\1/p' | tr ' ' ';'"
+        COMMAND "sh" "-c" "lscpu | sed -n 's/Flags:\\s*\\(.*\\)/\\1/p'"
         OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE TVL_LSCPU_FLAGS
     )
 endif()
 if(TVL_LSCPU_FLAGS STREQUAL "")
     message(FATAL_ERROR "failed to deduce TVL_LSCPU_FLAGS, please specify manually")
 endif()
+string(REGEX REPLACE "[ \t]+" ";" LSCPU_FLAGS_LIST "${TVL_LSCPU_FLAGS}")
 
 # run generator, this could be made 'lazy' using the strategy from tslgen.cmake
 set(GENERATOR_OUTPUT_PATH "${CMAKE_CURRENT_BINARY_DIR}/generator_output")
-message(STATUS "lscpu flags: ${TVL_LSCPU_FLAGS}")
+message(STATUS "lscpu flags: ${LSCPU_FLAGS_LIST}")
 message(STATUS "running generator...")
 execute_process(
-    COMMAND python3 "${CMAKE_CURRENT_SOURCE_DIR}/main.py" --no-workaround-warnings --no-concepts -o "${GENERATOR_OUTPUT_PATH}" --targets ${TVL_LSCPU_FLAGS}
+    COMMAND python3 "${CMAKE_CURRENT_SOURCE_DIR}/main.py" --no-workaround-warnings --no-concepts -o "${GENERATOR_OUTPUT_PATH}" --targets ${LSCPU_FLAGS_LIST}
     COMMAND_ERROR_IS_FATAL ANY
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,16 +13,32 @@ if(TVL_LSCPU_FLAGS STREQUAL "")
     message(FATAL_ERROR "failed to deduce TVL_LSCPU_FLAGS, please specify manually")
 endif()
 string(REGEX REPLACE "[ \t]+" ";" LSCPU_FLAGS_LIST "${TVL_LSCPU_FLAGS}")
-
-# run generator, this could be made 'lazy' using the strategy from tslgen.cmake
-set(GENERATOR_OUTPUT_PATH "${CMAKE_CURRENT_BINARY_DIR}/generator_output")
 message(STATUS "lscpu flags: ${LSCPU_FLAGS_LIST}")
-message(STATUS "running generator...")
+
+# trigger reconfiguration if the source files of the generator changed
+file(GLOB_RECURSE TVL_GENERATOR_SOURCES CONFIGURE_DEPENDS
+    "config/*.template"
+    "config/*.yaml"
+    "static_files/*.yaml"
+    "core/*.py"
+    "expansions/*.py"
+    "utils/*.py"
+    "primitive_data/extensions/*.yaml"
+    "primitive_data/primitives/*.yaml"
+)
+set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${TVL_GENERATOR_SOURCES})
+
+# run the generator
+set(GENERATOR_OUTPUT_PATH "${CMAKE_CURRENT_BINARY_DIR}/generator_output")
+find_package(Python3 REQUIRED)
+
+message(STATUS "Running TVL Generator...")
 execute_process(
-    COMMAND python3 "${CMAKE_CURRENT_SOURCE_DIR}/main.py" --no-workaround-warnings --no-concepts -o "${GENERATOR_OUTPUT_PATH}" --targets ${LSCPU_FLAGS_LIST}
+    COMMAND "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/main.py" --no-workaround-warnings --no-concepts -o "${GENERATOR_OUTPUT_PATH}" --targets ${LSCPU_FLAGS_LIST}
     COMMAND_ERROR_IS_FATAL ANY
 )
 
+# run the CMakeLists.txt created by the generator
 add_subdirectory("${GENERATOR_OUTPUT_PATH}")
 
 # disable -W-attributes

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ sphinx
 sphinx_rtd_theme
 breathe
 exhale
+py-cpuinfo


### PR DESCRIPTION
This just fixes some quality of life issues for developers of this:

- add a CMakeLists.txt that automatically runs the generator (and reruns if the generator sources changed).  
  (This Resolves #8)
- adds /.vscode, tvlgen.log.* and /build to the .gitignore
- removes the 55MiB tvlgen.zip blob from the repository


