### PR TITLE
Extended Schema to support different target extensions for casting

### DIFF
--- a/config/generator/tvl_generator_schema.yaml
+++ b/config/generator/tvl_generator_schema.yaml
@@ -189,6 +189,10 @@ primitive_specialization_optionals: &definition_optionals_schema
       type: "dict"
       default: {}
       brief: todo
+   additional_simd_template_extension:
+      type: "str"
+      default: ""
+      brief: "Return vector extension, which is used for casts."
    includes: *includes_schema
 
 primitive_definition: &definition_schema

--- a/config/generator/tvl_templates/core/primitive_definition.template
+++ b/config/generator/tvl_templates/core/primitive_definition.template
@@ -16,6 +16,7 @@
    return_template_type='',
    additional_templates='',
    additional_template_params='',
+   additional_target_extension='',
    simd_register_length='') %}
 {% if vector_length_agnostic %}
    {% set ns.simd_register_length = ', VectorSize' %}
@@ -57,8 +58,13 @@
    {% endif %}
 {% endfor %}
 {% if additional_simd_template_parameter != "" %}
-{% set ns.using_return_type = 'using ' ~ additional_simd_template_parameter ~ ' = simd<' ~ additional_simd_template_base_type ~ ', ' ~ target_extension ~ ns.simd_register_length ~ '>;' %}
-{% set ns.return_template_type = 'simd<' ~ additional_simd_template_base_type ~ ', ' ~ target_extension ~ ns.simd_register_length ~ '>, ' %}
+    {% if additional_simd_template_extension != "" %}
+        {% set ns.additional_target_extension = additional_simd_template_extension %}
+    {% else %}
+        {% set ns.additional_target_extension = target_extension %}
+    {% endif %}
+    {% set ns.using_return_type = 'using ' ~ additional_simd_template_parameter ~ ' = simd<' ~ additional_simd_template_base_type ~ ', ' ~ ns.additional_target_extension ~ ns.simd_register_length ~ '>;' %}
+    {% set ns.return_template_type = 'simd<' ~ additional_simd_template_base_type ~ ', ' ~ ns.additional_target_extension ~ ns.simd_register_length ~ '>, ' %}
 {% endif %}
 {% if additional_non_specialized_template_parameters|length > 0 %}
 {% set types_joiner = joiner(",") %}

--- a/core/model/tvl_primitive.py
+++ b/core/model/tvl_primitive.py
@@ -250,8 +250,6 @@ class TVLPrimitive:
 
     @property
     def definitions(self) -> Generator[TVLPrimitive.Definition, None, None]:
-        if self.__declaration.name == "cast":
-            print("@@@@@@@NOW")
         for definition in self.__definitions:
             yield definition
 

--- a/core/model/tvl_primitive.py
+++ b/core/model/tvl_primitive.py
@@ -72,6 +72,12 @@ class TVLPrimitive:
                 yield (alist[i], blist[i])
 
         @classmethod
+        def map_types_m2m(clscls, alist: List[str]) -> Generator[Tuple[str, str], None, None]:
+            for i in alist:
+                yield(i,i)
+
+
+        @classmethod
         def map_types_from_dict(cls, alist: List[str], bdict: Dict[str, List[str]]) -> Generator[Tuple[str, str], None, None]:
             for i in alist:
                 if i not in bdict:
@@ -137,7 +143,7 @@ class TVLPrimitive:
         def types(self) -> Generator[Tuple[str, str], None, None]:
             ctypes_list = self.ctypes
             return_vector_basetypes_list = self.additional_simd_template_base_types
-            if (len(return_vector_basetypes_list) == 0) and (len(self.additional_simd_template_base_type_mapping_dict) == 0):
+            if (len(return_vector_basetypes_list) == 0) and (len(self.additional_simd_template_base_type_mapping_dict) == 0) and self.__data_dict["additional_simd_template_extension"] == "":
                 for t in ctypes_list:
                     yield (t, "")
             elif (len(ctypes_list) == 1) and (len(return_vector_basetypes_list) > 1):
@@ -148,6 +154,8 @@ class TVLPrimitive:
                 yield from TVLPrimitive.Definition.map_types_one2one(ctypes_list, return_vector_basetypes_list)
             elif len(self.additional_simd_template_base_type_mapping_dict) > 0:
                 yield from TVLPrimitive.Definition.map_types_from_dict(ctypes_list, self.additional_simd_template_base_type_mapping_dict)
+            elif len(ctypes_list) > 0 and len(return_vector_basetypes_list) == 0:
+                yield from TVLPrimitive.Definition.map_types_m2m(ctypes_list)
             else:
                 yield from TVLPrimitive.Definition.map_types_cartesian(ctypes_list, return_vector_basetypes_list)
 
@@ -242,6 +250,8 @@ class TVLPrimitive:
 
     @property
     def definitions(self) -> Generator[TVLPrimitive.Definition, None, None]:
+        if self.__declaration.name == "cast":
+            print("@@@@@@@NOW")
         for definition in self.__definitions:
             yield definition
 


### PR DESCRIPTION
For cast operations we want to cast from one extension, e.g., sse, to another one, e.g., avx2, while keeping the underlying base type. This is now possible.